### PR TITLE
Arming a security system no longer requires 2fa

### DIFF
--- a/src/types/security-system.ts
+++ b/src/types/security-system.ts
@@ -140,6 +140,10 @@ export class SecuritySystem {
 
     switch (command.execution[0].command) {
       case ('action.devices.commands.ArmDisarm'): {
+        if (command.execution[0].params.arm === true) {
+          return false;
+        }
+
         return true;
       }
     }


### PR DESCRIPTION
This removes the 2fa check when arming a security system.