### PR TITLE
Allow twoFactorAuthPin with leading zeros

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -27,7 +27,8 @@
       },
       "twoFactorAuthPin": {
         "placeholder": "Two Factor Authentication Pin Code",
-        "type": "integer"
+        "type": "string"
+        "pattern": "^[0-9]*$"
       },
       "debug": {
         "title": "Enable Debug Logging",


### PR DESCRIPTION
Currently, the `twoFactorAuthPin` is being stored as an integer. When a PIN is entered which has a leading zero, because the PIN is stored as an integer, the leading zero is dropped, but this is done without the user knowing. As a result, when the user tries to use the PIN they believe they entered, Google Home does not accept the PIN.

In my proposed change, I've changed `twoFactorAuthPin`'s `type` to `string`, which I've manually done in a JSON config to confirm Google Home still recognizes the PIN in this way.
I have also added a `pattern` which contains regex (which I believe) should ensure users can enter only strings of any length comprised only of numbers from 0-9.