### PR TITLE
List "speaker" under supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Control your supported [Homebridge](https://github.com/nfarina/homebridge) acces
 
 ## Supported Device Types
 
+* Speaker
 * Switch
 * Outlet
 * Light Bulb


### PR DESCRIPTION
Not listing "speaker" in the list here made me do a double-take --  I see it above, and it's surprising not to see it in the list too. This commit adds it! :)