### PR TITLE
Fix logging spelling and capitalization

### DIFF
--- a/src/hap.ts
+++ b/src/hap.ts
@@ -398,7 +398,7 @@ export class Hap {
 
           // if 2fa is forced for this service type, but a pin has not been set ignore the service
           if (this.types[service.serviceType].twoFactorRequired && !this.config.twoFactorAuthPin && !this.config.disablePinCodeRequirement) {
-            this.log.warn(`Not registering ${service.serviceName} - Pin cide has not been set and is required for secure ` +
+            this.log.warn(`Not registering ${service.serviceName} - PIN code has not been set and is required for secure ` +
               `${service.serviceType} accessory types. See https://git.io/JUQWX`);
             return;
           }


### PR DESCRIPTION
Fixed spelling and capitalization of logging of pin-locked devices that have no pin set.