### PR TITLE
Implement channel/input selection of Television device

### DIFF
--- a/src/hap.ts
+++ b/src/hap.ts
@@ -83,6 +83,8 @@ export class Hap {
     Characteristic.CurrentRelativeHumidity,
     Characteristic.SecuritySystemTargetState,
     Characteristic.SecuritySystemCurrentState,
+    Characteristic.ActiveIdentifier,
+    Characteristic.Mute,
   ];
 
   instanceBlacklist: Array<string> = [];

--- a/src/hap.ts
+++ b/src/hap.ts
@@ -158,7 +158,6 @@ export class Hap {
     await this.getAccessories();
     await this.buildSyncResponse();
     await this.registerCharacteristicEventHandlers();
-    //this.log.info(`Found ${this.services.length} services.`)
   }
 
   /**
@@ -547,11 +546,7 @@ export class Hap {
 
     for (const uniqueId of pendingStateReport) {
       const service = this.services.find(x => x.uniqueId === uniqueId);
-      if (service) {
-	states[service.uniqueId] = this.types[service.serviceType].query(service);
-      } else {
-	this.log.error(`uniqueId could not be found: ${JSON.stringify(pendingStateReport)}`);
-      }
+      states[service.uniqueId] = this.types[service.serviceType].query(service);
     }
 
     return await this.sendStateReport(states);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -60,6 +60,7 @@ export interface HapService {
   aid?: number;
   serviceType?: string;
   instance?: Instance;
+  extras?: any;
 }
 
 export interface HapAccessory {

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -124,12 +124,6 @@ export class Television {
       if (i = service.extras.inputs.find(x => x.Identifier === c.value)) {
 	response.currentInput =  i.Name;
       }
-      else {
-	i = service.extras.channels.find(x => x.Identifier === c.value);
-      }
-      const a = service.characteristics.find(x => x.type === Characteristic.Active).value;
-      const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-      console.log(`[${new Date().toLocaleString()}] Current input selection of ${d} is '${i.ConfiguredName}' and response is '${response.currentInput}'(${a}).` );
     }
     //console.log(response);
     
@@ -194,7 +188,6 @@ export class Television {
               }],
 	    };
 	    service.extras.channels.lastchannel = c.Identifier;
-	    // service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
 	    return { payload };
 	  }
 	} else if (command.execution[0].params?.channelNumber) {
@@ -208,7 +201,6 @@ export class Television {
               }],
 	    };
 	    service.extras.channels.lastchannel = c.Identifier;
-	    // service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
 	    return { payload };
 	  }
       //} else if (command.execution[0].params?.channelName) {
@@ -221,8 +213,6 @@ export class Television {
 	let c = service.extras.channels.lastchannel !== undefined ?
 	    service.extras.channels.lastchannel :
 	    service.extras.channels[n - 1].Identifier;
-	const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-	// console.log(`Current channel selection of ${d} is ${c}.` );
 	if (change > 0) {
 	  if (++c > service.extras.channels[n - 1].Identifier)
 	    c = service.extras.channels[0].Identifier;
@@ -230,7 +220,6 @@ export class Television {
 	  if (--c < service.extras.channels[0].Identifier)
 	    c = service.extras.channels[n - 1].Identifier;
 	}
-	// console.log(`Next channel selection of ${d} is ${c}.` );
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -243,12 +232,9 @@ export class Television {
       }
       case ('action.devices.returnChannel'): {
 	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
-	const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-	// console.log(`Current channel selection of ${d} is ${c}.` );
 	c = service.extras.channels.lastchannel !== undefined ?
 	  service.extras.channels.lastchannel :
 	  service.extras.channels[0].Identifier;
-	// console.log(`Next channel selection of ${d} is ${c}.` );
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -273,15 +259,12 @@ export class Television {
 	  const states = {
 	    currentInput: c.Name,
 	  }
-	  // service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
 	  return { payload, states };
 	}
 	break;
       }
       case ('action.devices.commands.NextInput'): {
 	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
-	let d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-	// console.log(`Current input selection of ${d} is ${c}.` );
 	let n = service.extras.inputs.length;
 	if (service.extras.channels.find(x => x.Identifier === c)) {
 	  c = service.extras.inputs[0].Identifier;
@@ -290,7 +273,6 @@ export class Television {
 	} else if (n > 1) {
 	  c++;
 	}
-	// console.log(`Next input selection of ${d} is ${c}.` );
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -305,8 +287,6 @@ export class Television {
       }
       case ('action.devices.commands.PreviousInput'): {
 	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
-	let d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-	// console.log(`Current input selection of ${d} is ${c}.` );
 	let n = service.extras.inputs.length;
 	if (service.extras.channels.find(x => x.Identifier === c)) {
 	  c = service.extras.inputs[n - 1].Identifier;
@@ -315,7 +295,6 @@ export class Television {
 	} else if (n > 1) {
 	  c--;
 	}
-	// console.log(`Next input selection of ${d} is ${c}.` );
 	const payload = {
           characteristics: [{
 	    aid: service.aid,

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -10,9 +10,6 @@ export class Television {
       //'action.devices.traits.Toggles',
       //'action.devices.traits.AppSelector',
       //'action.devices.traits.TransportControl',
-      //'action.devices.traits.Volume',
-      //'action.devices.traits.Channel',
-      //'action.devices.traits.InputSelector'
     ];
     let attributes = {
       commandOnlyOnOff: false,	//OnOff
@@ -31,20 +28,30 @@ export class Television {
       attributes.commandOnlyChannels = true;
       attributes.availableChannels = [];
       for (const c of service.extras.channels) {
-	let x = {
+	attributes.availableChannels.push({
 	  key: c.Name,
 	  names: [c.ConfiguredName],
 	  number: `${c.Identifier + 1}`,
-	};
-	attributes.availableChannels.push(x);
+	});
       }
     }
     if (service.extras?.inputs && service.extras.inputs.length > 0) {
       traits.push('action.devices.traits.InputSelector');
-      attributes.commandOnlyInputSelector = true;
-      attributes.availableInputs = [];
+      attributes.commandOnlyInputSelector = false;
+      attributes.orderedInputs = true;
+      attributes.availableInputs = [{
+	key: "_tv",	//dummy for stations
+	names: [
+	  {
+	    lang: "en",
+	    name_synonym: [
+	      "_tv",
+	    ]
+	  }
+	]
+      }];
       for (const c of service.extras.inputs) {
-	let x = {
+	attributes.availableInputs.push({
 	  key: c.Name,
 	  names: [
 	    {
@@ -54,8 +61,7 @@ export class Television {
 	      ]
 	    }
 	  ],
-	};
-	attributes.availableInputs.push(x);
+	});
       }
     }
     //console.log(JSON.stringify(traits));
@@ -101,17 +107,19 @@ export class Television {
     if (c = service.characteristics.find(x => x.type === Characteristic.Mute)) {
       response.isMuted =  c.value ? true : false;
     }
-    // if (c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier)) {	// meaningless
-    //   let i;
-    //   console.log(c.value);
-    //   if (i = service.extras.inputs.find(x => x.Identifier === c.value)) {
-    // 	response.currentInput = i.Name;
-    //   }
-    //   // else if (i = service.extras.channels.find(x => x.Identifier === c.value)) {
-    //   // 	response.currentInput =  i.name;
-    //   // }
-    // }
-    // console.log(response);
+    if (c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier)) {
+      let i;
+      response.currentInput =  "_tv";
+      if (i = service.extras.inputs.find(x => x.Identifier === c.value)) {
+	response.currentInput =  i.Name;
+      }
+      else {
+	i = service.extras.channels.find(x => x.Identifier === c.value);
+      }
+      const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
+      console.log(`Current input selection of ${d} is ${i.ConfiguredName} and response is ${response.currentInput}.` );
+    }
+    //console.log(response);
     
     return response;
     
@@ -147,9 +155,8 @@ export class Television {
         };
         return { payload };
       }
-      // case ('action.devices.commands.setVolume'): {	// No proper characteristic
-      // 	return { payload: { characteristics: [] } };
-      // }
+   // case ('action.devices.commands.setVolume'): {	// No proper characteristic
+   // }
       case ('action.devices.commands.volumeRelative'): {
 	// Characteristic.VolumeSelector.INCREMENT = 0;
 	// Characteristic.VolumeSelector.DECREMENT = 1;
@@ -163,51 +170,162 @@ export class Television {
         return { payload };
       }
       case ('action.devices.commands.selectChannel'): {
-	let payload = null;
 	let c;
 	if (command.execution[0].params?.channelCode) {
 	  const code = command.execution[0].params.channelCode;
 	  if (c = service.extras.channels.find(x => x.Name === code)) {
-            payload = {
+            const payload = {
               characteristics: [{
 		aid: service.aid,
 		iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
 		value: c.Identifier,
               }],
 	    };
+	    service.extras.channels.lastchannel = c.Identifier;
+	    service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
+	    return { payload };
 	  }
 	} else if (command.execution[0].params?.channelNumber) {
 	  const number = parseInt(command.execution[0].params.channelNumber) - 1;
 	  if (c = service.extras.channels.find(x => x.Identifier === number)) {
-            payload = {
+            const payload = {
               characteristics: [{
 		aid: service.aid,
 		iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
 		value: c.Identifier,
               }],
 	    };
+	    service.extras.channels.lastchannel = c.Identifier;
+	    service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
+	    return { payload };
 	  }
+      //} else if (command.execution[0].params?.channelName) {
 	}
+	break;
+      }
+      case ('action.devices.commands.relativeChannel'): {
+	const change = command.execution[0].params?.relativeChannelChange;
+	const n = service.extras.channels.length;
+	let c = service.extras.channels.lastchannel !== undefined ?
+	    service.extras.channels.lastchannel :
+	    service.extras.channels[n - 1].Identifier;
+	const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
+	console.log(`Current channel selection of ${d} is ${c}.` );
+	if (change > 0) {
+	  if (++c > service.extras.channels[n - 1].Identifier)
+	    c = service.extras.channels[0].Identifier;
+	} else if (change < 0) {
+	  if (--c < service.extras.channels[0].Identifier)
+	    c = service.extras.channels[n - 1].Identifier;
+	}
+	console.log(`Next channel selection of ${d} is ${c}.` );
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+	    value: c,
+          }],
+	};
+	service.extras.channels.lastchannel = c;
+	// force to update to ready next channel operations.
+	service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
+	return { payload };
+      }
+      case ('action.devices.returnChannel'): {
+	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
+	const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
+	console.log(`Current channel selection of ${d} is ${c}.` );
+	c = service.extras.channels.lastchannel !== undefined ?
+	  service.extras.channels.lastchannel :
+	  service.extras.channels[0].Identifier;
+	console.log(`Next channel selection of ${d} is ${c}.` );
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+	    value: c,
+          }],
+	};
+	service.extras.channels.lastchannel = c;
+	// force to update to ready next channel operations.
+	service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload };
       }
       case ('action.devices.commands.SetInput'): {
 	const input = command.execution[0].params?.newInput;
-	let payload = null;
 	let c;
 	if (c = service.extras.inputs.find(x => x.Name === input)) {
-	  payload = {
+	  const payload = {
             characteristics: [{
 	      aid: service.aid,
 	      iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
 	      value: parseInt(c.Identifier),
             }],
 	  };
+	  const states = {
+	    currentInput: c.Name,
+	  }
+	  service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
+	  return { payload, states };
 	}
-	return { payload };
+	break;
+      }
+      case ('action.devices.commands.NextInput'): {
+	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
+	let d = service.characteristics.find(x => x.type === Characteristic.Name).value;
+	console.log(`Current input selection of ${d} is ${c}.` );
+	let n = service.extras.inputs.length;
+	if (service.extras.channels.find(x => x.Identifier === c)) {
+	  c = service.extras.inputs[0].Identifier;
+	} else if (c === service.extras.inputs[n - 1].Identifier) {
+	  c = service.extras.inputs[0].Identifier;
+	} else if (n > 1) {
+	  c++;
+	}
+	console.log(`Next input selection of ${d} is ${c}.` );
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+	    value: c,
+          }],
+	};
+	const states = {
+	  currentInput: service.extras.inputs.find(x => x.Identifier === c).Name,
+	}
+	// force to update to ready next Next/Previous
+	service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
+	return { payload, states };
+      }
+      case ('action.devices.commands.PreviousInput'): {
+	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
+	let d = service.characteristics.find(x => x.type === Characteristic.Name).value;
+	console.log(`Current input selection of ${d} is ${c}.` );
+	let n = service.extras.inputs.length;
+	if (service.extras.channels.find(x => x.Identifier === c)) {
+	  c = service.extras.inputs[n - 1].Identifier;
+	} else if (c === service.extras.inputs[0].Identifier) {
+	  c = service.extras.inputs[n - 1].Identifier;
+	} else if (n > 1) {
+	  c--;
+	}
+	console.log(`Next input selection of ${d} is ${c}.` );
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+	    value: c,
+          }],
+	};
+	const states = {
+	  currentInput: service.extras.inputs.find(x => x.Identifier === c).Name,
+	}
+	// force to update to ready next Next/Previous
+	service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
+	return { payload, states };
       }
     }
     
     return { payload: null };
   }
-
 }

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -1,3 +1,4 @@
+
 import { Characteristic } from '../hap-types';
 import { HapService, AccessoryTypeExecuteResponse } from '../interfaces';
 
@@ -182,7 +183,7 @@ export class Television {
               }],
 	    };
 	    service.extras.channels.lastchannel = c.Identifier;
-	    service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
+	    // service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
 	    return { payload };
 	  }
 	} else if (command.execution[0].params?.channelNumber) {
@@ -196,7 +197,7 @@ export class Television {
               }],
 	    };
 	    service.extras.channels.lastchannel = c.Identifier;
-	    service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
+	    // service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
 	    return { payload };
 	  }
       //} else if (command.execution[0].params?.channelName) {
@@ -210,7 +211,7 @@ export class Television {
 	    service.extras.channels.lastchannel :
 	    service.extras.channels[n - 1].Identifier;
 	const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-	console.log(`Current channel selection of ${d} is ${c}.` );
+	// console.log(`Current channel selection of ${d} is ${c}.` );
 	if (change > 0) {
 	  if (++c > service.extras.channels[n - 1].Identifier)
 	    c = service.extras.channels[0].Identifier;
@@ -218,7 +219,7 @@ export class Television {
 	  if (--c < service.extras.channels[0].Identifier)
 	    c = service.extras.channels[n - 1].Identifier;
 	}
-	console.log(`Next channel selection of ${d} is ${c}.` );
+	// console.log(`Next channel selection of ${d} is ${c}.` );
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -228,17 +229,17 @@ export class Television {
 	};
 	service.extras.channels.lastchannel = c;
 	// force to update to ready next channel operations.
-	service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
+	// service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload };
       }
       case ('action.devices.returnChannel'): {
 	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
 	const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-	console.log(`Current channel selection of ${d} is ${c}.` );
+	// console.log(`Current channel selection of ${d} is ${c}.` );
 	c = service.extras.channels.lastchannel !== undefined ?
 	  service.extras.channels.lastchannel :
 	  service.extras.channels[0].Identifier;
-	console.log(`Next channel selection of ${d} is ${c}.` );
+	// console.log(`Next channel selection of ${d} is ${c}.` );
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -248,7 +249,7 @@ export class Television {
 	};
 	service.extras.channels.lastchannel = c;
 	// force to update to ready next channel operations.
-	service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
+	// service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload };
       }
       case ('action.devices.commands.SetInput'): {
@@ -265,7 +266,7 @@ export class Television {
 	  const states = {
 	    currentInput: c.Name,
 	  }
-	  service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
+	  // service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c.Identifier;
 	  return { payload, states };
 	}
 	break;
@@ -273,7 +274,7 @@ export class Television {
       case ('action.devices.commands.NextInput'): {
 	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
 	let d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-	console.log(`Current input selection of ${d} is ${c}.` );
+	// console.log(`Current input selection of ${d} is ${c}.` );
 	let n = service.extras.inputs.length;
 	if (service.extras.channels.find(x => x.Identifier === c)) {
 	  c = service.extras.inputs[0].Identifier;
@@ -282,7 +283,7 @@ export class Television {
 	} else if (n > 1) {
 	  c++;
 	}
-	console.log(`Next input selection of ${d} is ${c}.` );
+	// console.log(`Next input selection of ${d} is ${c}.` );
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -294,13 +295,13 @@ export class Television {
 	  currentInput: service.extras.inputs.find(x => x.Identifier === c).Name,
 	}
 	// force to update to ready next Next/Previous
-	service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
+	// service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload, states };
       }
       case ('action.devices.commands.PreviousInput'): {
 	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
 	let d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-	console.log(`Current input selection of ${d} is ${c}.` );
+	// console.log(`Current input selection of ${d} is ${c}.` );
 	let n = service.extras.inputs.length;
 	if (service.extras.channels.find(x => x.Identifier === c)) {
 	  c = service.extras.inputs[n - 1].Identifier;
@@ -309,7 +310,7 @@ export class Television {
 	} else if (n > 1) {
 	  c--;
 	}
-	console.log(`Next input selection of ${d} is ${c}.` );
+	// console.log(`Next input selection of ${d} is ${c}.` );
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -321,7 +322,7 @@ export class Television {
 	  currentInput: service.extras.inputs.find(x => x.Identifier === c).Name,
 	}
 	// force to update to ready next Next/Previous
-	service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
+	// service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload, states };
       }
     }

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -3,12 +3,69 @@ import { HapService, AccessoryTypeExecuteResponse } from '../interfaces';
 
 export class Television {
   sync(service: HapService) {
+    let traits = [
+      'action.devices.traits.OnOff',
+      //'action.devices.traits.MediaState',
+      //'action.devices.traits.Modes',
+      //'action.devices.traits.Toggles',
+      //'action.devices.traits.AppSelector',
+      //'action.devices.traits.TransportControl',
+      //'action.devices.traits.Volume',
+      //'action.devices.traits.Channel',
+      //'action.devices.traits.InputSelector'
+    ];
+    let attributes = {
+      commandOnlyOnOff: false,	//OnOff
+      queryOnlyOnOff: false,
+      //supportActivityState: false,//MediaState
+      //supportPlaybackState: false,
+    } as any;
+    if (service.characteristics.find(x => x.type === Characteristic.VolumeSelector)) {
+      traits.push('action.devices.traits.Volume');
+      attributes.volumeCanMuteAndUnmute = service.characteristics.find(x => x.type === Characteristic.Mute) ? true : false;
+      attributes.volumeMaxLevel = 20;	//Volume. Just in case for a relative operations
+      attributes.commandOnlyVolume = true;
+    }
+    if (service.extras?.channels && service.extras.channels.length > 0) {
+      traits.push('action.devices.traits.Channel');
+      attributes.commandOnlyChannels = true;
+      attributes.availableChannels = [];
+      for (const c of service.extras.channels) {
+	let x = {
+	  key: c.Name,
+	  names: [c.ConfiguredName],
+	  number: `${c.Identifier + 1}`,
+	};
+	attributes.availableChannels.push(x);
+      }
+    }
+    if (service.extras?.inputs && service.extras.inputs.length > 0) {
+      traits.push('action.devices.traits.InputSelector');
+      attributes.commandOnlyInputSelector = true;
+      attributes.availableInputs = [];
+      for (const c of service.extras.inputs) {
+	let x = {
+	  key: c.Name,
+	  names: [
+	    {
+	      lang: "en",
+	      name_synonym: [
+		c.ConfiguredName,
+	      ]
+	    }
+	  ],
+	};
+	attributes.availableInputs.push(x);
+      }
+    }
+    //console.log(JSON.stringify(traits));
+    //console.log(JSON.stringify(attributes, null, 2));
+
     return {
       id: service.uniqueId,
       type: 'action.devices.types.TV',
-      traits: [
-        'action.devices.traits.OnOff',
-      ],
+      traits: traits,
+      attributes: attributes,
       name: {
         defaultNames: [
           service.serviceName,
@@ -33,10 +90,35 @@ export class Television {
   }
 
   query(service: HapService) {
-    return {
+    let c;
+    let response = {
       on: service.characteristics.find(x => x.type === Characteristic.Active).value ? true : false,
       online: true,
-    };
+    } as any;
+    if (service.characteristics.find(x => x.type === Characteristic.VolumeSelector)) {
+      response.currentVolume = 10;
+    }
+    if (c = service.characteristics.find(x => x.type === Characteristic.Mute)) {
+      response.isMuted =  c.value ? true : false;
+    }
+    // if (c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier)) {	// meaningless
+    //   let i;
+    //   console.log(c.value);
+    //   if (i = service.extras.inputs.find(x => x.Identifier === c.value)) {
+    // 	response.currentInput = i.Name;
+    //   }
+    //   // else if (i = service.extras.channels.find(x => x.Identifier === c.value)) {
+    //   // 	response.currentInput =  i.name;
+    //   // }
+    // }
+    // console.log(response);
+    
+    return response;
+    
+    // return {
+    //   on: service.characteristics.find(x => x.type === Characteristic.Active).value ? true : false,
+    //   online: true,
+    // };
   }
 
   execute(service: HapService, command): AccessoryTypeExecuteResponse {
@@ -55,7 +137,78 @@ export class Television {
         };
         return { payload };
       }
+      case ('action.devices.commands.mute'): {
+        const payload = {
+          characteristics: [{
+            aid: service.aid,
+            iid: service.characteristics.find(x => x.type === Characteristic.Mute).iid,
+            value: command.execution[0].params.mute ? 1 : 0,
+          }],
+        };
+        return { payload };
+      }
+      // case ('action.devices.commands.setVolume'): {	// No proper characteristic
+      // 	return { payload: { characteristics: [] } };
+      // }
+      case ('action.devices.commands.volumeRelative'): {
+	// Characteristic.VolumeSelector.INCREMENT = 0;
+	// Characteristic.VolumeSelector.DECREMENT = 1;
+        const payload = {
+          characteristics: [{
+            aid: service.aid,
+            iid: service.characteristics.find(x => x.type === Characteristic.VolumeSelector).iid,
+            value: command.execution[0].params.relativeSteps < 0 ? 1 : 0,
+          }],
+        };
+        return { payload };
+      }
+      case ('action.devices.commands.selectChannel'): {
+	let value = 0;
+	if (command.execution[0].params.channelCode) {
+	  const code = command.execution[0].params.channelCode;
+	  const c = service.extras.channels.find(x => x.name === code);
+	  if (c) {
+	    value = parseInt(c.Identifier) - 1;
+	  }
+	} else if (command.execution[0].params.channelNumber) {
+	  //console.log(command.execution[0].params.channelNumber);
+	  const number = parseInt(command.execution[0].params.channelNumber) - 1;
+	  const c = service.extras.channels.find(x => x.Identifier === number);
+	  //console.log(c);
+	  if (c) {
+	    value = c.Identifier;
+	  }
+	}
+        const payload = {
+          characteristics: [{
+            aid: service.aid,
+            iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+            value: value,
+          }],
+        };
+	//console.log(payload);
+        return { payload };
+      }
+      case ('action.devices.commands.SetInput'): {
+	let value = 0;
+	const input = command.execution[0].params.newInput;
+	const c = service.extras.inputs.find(x => x.name === input);
+	if (c) {
+	  value = parseInt(c.Identifier);
+	}
+        const payload = {
+          characteristics: [{
+            aid: service.aid,
+            iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+            value: value,
+          }],
+        };
+	//console.log(payload);
+        return { payload };
+      }
     }
+    
+    return { payload: { characteristics: [] } };
   }
 
 }

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -163,52 +163,51 @@ export class Television {
         return { payload };
       }
       case ('action.devices.commands.selectChannel'): {
-	let value = 0;
-	if (command.execution[0].params.channelCode) {
+	let payload = null;
+	let c;
+	if (command.execution[0].params?.channelCode) {
 	  const code = command.execution[0].params.channelCode;
-	  const c = service.extras.channels.find(x => x.name === code);
-	  if (c) {
-	    value = parseInt(c.Identifier) - 1;
+	  if (c = service.extras.channels.find(x => x.Name === code)) {
+            payload = {
+              characteristics: [{
+		aid: service.aid,
+		iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+		value: c.Identifier,
+              }],
+	    };
 	  }
-	} else if (command.execution[0].params.channelNumber) {
-	  //console.log(command.execution[0].params.channelNumber);
+	} else if (command.execution[0].params?.channelNumber) {
 	  const number = parseInt(command.execution[0].params.channelNumber) - 1;
-	  const c = service.extras.channels.find(x => x.Identifier === number);
-	  //console.log(c);
-	  if (c) {
-	    value = c.Identifier;
+	  if (c = service.extras.channels.find(x => x.Identifier === number)) {
+            payload = {
+              characteristics: [{
+		aid: service.aid,
+		iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+		value: c.Identifier,
+              }],
+	    };
 	  }
 	}
-        const payload = {
-          characteristics: [{
-            aid: service.aid,
-            iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
-            value: value,
-          }],
-        };
-	//console.log(payload);
-        return { payload };
+	return { payload };
       }
       case ('action.devices.commands.SetInput'): {
-	let value = 0;
-	const input = command.execution[0].params.newInput;
-	const c = service.extras.inputs.find(x => x.Name === input);
-	if (c) {
-	  value = parseInt(c.Identifier);
+	const input = command.execution[0].params?.newInput;
+	let payload = null;
+	let c;
+	if (c = service.extras.inputs.find(x => x.Name === input)) {
+	  payload = {
+            characteristics: [{
+	      aid: service.aid,
+	      iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
+	      value: parseInt(c.Identifier),
+            }],
+	  };
 	}
-        const payload = {
-          characteristics: [{
-            aid: service.aid,
-            iid: service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).iid,
-            value: value,
-          }],
-        };
-	//console.log(payload);
-        return { payload };
+	return { payload };
       }
     }
     
-    return { payload: { characteristics: [] } };
+    return { payload: null };
   }
 
 }

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -1,4 +1,3 @@
-
 import { Characteristic } from '../hap-types';
 import { HapService, AccessoryTypeExecuteResponse } from '../interfaces';
 

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -5,18 +5,20 @@ export class Television {
   sync(service: HapService) {
     let traits = [
       'action.devices.traits.OnOff',
-      //'action.devices.traits.MediaState',
+      'action.devices.traits.MediaState',
       //'action.devices.traits.Modes',
       //'action.devices.traits.Toggles',
-      //'action.devices.traits.AppSelector',
-      //'action.devices.traits.TransportControl',
+      'action.devices.traits.AppSelector',
+      'action.devices.traits.TransportControl',
     ];
     let attributes = {
       commandOnlyOnOff: false,	//OnOff
       queryOnlyOnOff: false,
-      //supportActivityState: false,//MediaState
-      //supportPlaybackState: false,
+      supportActivityState: false,//MediaState
+      supportPlaybackState: false,
     } as any;
+    attributes.availableApplications = [];
+    attributes.transportControlSupportedCommands = [];
     if (service.characteristics.find(x => x.type === Characteristic.VolumeSelector)) {
       traits.push('action.devices.traits.Volume');
       attributes.volumeCanMuteAndUnmute = service.characteristics.find(x => x.type === Characteristic.Mute) ? true : false;
@@ -116,8 +118,9 @@ export class Television {
       else {
 	i = service.extras.channels.find(x => x.Identifier === c.value);
       }
+      const a = service.characteristics.find(x => x.type === Characteristic.Active).value;
       const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
-      console.log(`Current input selection of ${d} is ${i.ConfiguredName} and response is ${response.currentInput}.` );
+      console.log(`[${new Date().toLocaleString()}] Current input selection of ${d} is '${i.ConfiguredName}' and response is '${response.currentInput}'(${a}).` );
     }
     //console.log(response);
     

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -211,15 +211,19 @@ export class Television {
 	const change = command.execution[0].params?.relativeChannelChange;
 	const n = service.extras.channels.length;
 	let c = service.extras.channels.lastchannel !== undefined ?
-	    service.extras.channels.lastchannel :
-	    service.extras.channels[n - 1].Identifier;
+	    service.extras.channels.findIndex(x => x.Identifier === service.extras.channels.lastchannel) :
+	    n - 1;
+	// const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
+	// console.log(`Current channel index of ${d} is ${c}.`);
 	if (change > 0) {
-	  if (++c > service.extras.channels[n - 1].Identifier)
-	    c = service.extras.channels[0].Identifier;
+	  if (++c > n - 1)
+	    c = 0;
 	} else if (change < 0) {
-	  if (--c < service.extras.channels[0].Identifier)
-	    c = service.extras.channels[n - 1].Identifier;
+	  if (--c < 0)
+	    c = n - 1;
 	}
+	// console.log(`Updated channel index of ${d} to ${c}.`);
+	c = service.extras.channels[c].Identifier;
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -267,12 +271,17 @@ export class Television {
 	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
 	let n = service.extras.inputs.length;
 	if (service.extras.channels.find(x => x.Identifier === c)) {
-	  c = service.extras.inputs[0].Identifier;
-	} else if (c === service.extras.inputs[n - 1].Identifier) {
-	  c = service.extras.inputs[0].Identifier;
-	} else if (n > 1) {
-	  c++;
+	  c = -1;
+	} else {
+	  c = service.extras.inputs.findIndex(x => x.Identifier === c);
 	}
+	// const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
+	// console.log(`Current input index of ${d} is ${c}.`);
+	if (++c > n - 1) {
+	  c = 0;
+	}
+	// console.log(`Updated input index of ${d} to ${c}.`);
+	c = service.extras.inputs[c].Identifier;
 	const payload = {
           characteristics: [{
 	    aid: service.aid,
@@ -289,12 +298,17 @@ export class Television {
 	let c = service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value;
 	let n = service.extras.inputs.length;
 	if (service.extras.channels.find(x => x.Identifier === c)) {
-	  c = service.extras.inputs[n - 1].Identifier;
-	} else if (c === service.extras.inputs[0].Identifier) {
-	  c = service.extras.inputs[n - 1].Identifier;
-	} else if (n > 1) {
-	  c--;
+	  c = -1;
+	} else {
+	  c = service.extras.inputs.findIndex(x => x.Identifier === c);
 	}
+	// const d = service.characteristics.find(x => x.type === Characteristic.Name).value;
+	// console.log(`Current input index of ${d} is ${c}.`);
+	if (--c < 0) {
+	  c = n - 1;
+	}
+	// console.log(`Updated input index of ${d} to ${c}.`);
+	c = service.extras.inputs[c].Identifier;
 	const payload = {
           characteristics: [{
 	    aid: service.aid,

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -192,7 +192,7 @@ export class Television {
       case ('action.devices.commands.SetInput'): {
 	let value = 0;
 	const input = command.execution[0].params.newInput;
-	const c = service.extras.inputs.find(x => x.name === input);
+	const c = service.extras.inputs.find(x => x.Name === input);
 	if (c) {
 	  value = parseInt(c.Identifier);
 	}

--- a/src/types/television.ts
+++ b/src/types/television.ts
@@ -19,6 +19,15 @@ export class Television {
     } as any;
     attributes.availableApplications = [];
     attributes.transportControlSupportedCommands = [];
+    if (service.characteristics.find(x => x.type === Characteristic.RemoteKey)) {
+      attributes.transportControlSupportedCommands = [
+	'STOP',
+	'RESUME',
+	'PAUSE',
+	'NEXT',
+	'PREVIOUS',
+      ];
+    }
     if (service.characteristics.find(x => x.type === Characteristic.VolumeSelector)) {
       traits.push('action.devices.traits.Volume');
       attributes.volumeCanMuteAndUnmute = service.characteristics.find(x => x.type === Characteristic.Mute) ? true : false;
@@ -230,8 +239,6 @@ export class Television {
           }],
 	};
 	service.extras.channels.lastchannel = c;
-	// force to update to ready next channel operations.
-	// service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload };
       }
       case ('action.devices.returnChannel'): {
@@ -250,8 +257,6 @@ export class Television {
           }],
 	};
 	service.extras.channels.lastchannel = c;
-	// force to update to ready next channel operations.
-	// service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload };
       }
       case ('action.devices.commands.SetInput'): {
@@ -296,8 +301,6 @@ export class Television {
 	const states = {
 	  currentInput: service.extras.inputs.find(x => x.Identifier === c).Name,
 	}
-	// force to update to ready next Next/Previous
-	// service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload, states };
       }
       case ('action.devices.commands.PreviousInput'): {
@@ -323,9 +326,70 @@ export class Television {
 	const states = {
 	  currentInput: service.extras.inputs.find(x => x.Identifier === c).Name,
 	}
-	// force to update to ready next Next/Previous
-	// service.characteristics.find(x => x.type === Characteristic.ActiveIdentifier).value = c;
 	return { payload, states };
+      }
+      // Characteristic.RemoteKey.REWIND = 0;
+      // Characteristic.RemoteKey.FAST_FORWARD = 1;
+      // Characteristic.RemoteKey.NEXT_TRACK = 2;
+      // Characteristic.RemoteKey.PREVIOUS_TRACK = 3;
+      // Characteristic.RemoteKey.ARROW_UP = 4;
+      // Characteristic.RemoteKey.ARROW_DOWN = 5;
+      // Characteristic.RemoteKey.ARROW_LEFT = 6;
+      // Characteristic.RemoteKey.ARROW_RIGHT = 7;
+      // Characteristic.RemoteKey.SELECT = 8;
+      // Characteristic.RemoteKey.BACK = 9;
+      // Characteristic.RemoteKey.EXIT = 10;
+      // Characteristic.RemoteKey.PLAY_PAUSE = 11;
+      // Characteristic.RemoteKey.INFORMATION = 15;
+      case ('action.devices.commands.mediaStop'): {
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.RemoteKey).iid,
+	    value: 9, // Characteristic.RemoteKey.BACK,
+          }],
+	};
+	return { payload };
+      }
+      case ('action.devices.commands.mediaResume'): {
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.RemoteKey).iid,
+	    value: 8, // Characteristic.RemoteKey.SELECT,
+          }],
+	};
+	return { payload };
+      }
+      case ('action.devices.commands.mediaPause'): {
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.RemoteKey).iid,
+	    value: 11, // Characteristic.RemoteKey.PLAY_PAUSE,
+          }],
+	};
+	return { payload };
+      }
+      case ('action.devices.commands.mediaNext'): {
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.RemoteKey).iid,
+	    value: 7, // Characteristic.RemoteKey.ARROW_RIGHT,
+          }],
+	};
+	return { payload };
+      }
+      case ('action.devices.commands.mediaPrevious'): {
+	const payload = {
+          characteristics: [{
+	    aid: service.aid,
+	    iid: service.characteristics.find(x => x.type === Characteristic.RemoteKey).iid,
+	    value: 6, // Characteristic.RemoteKey.ARROW_LEFT,
+          }],
+	};
+	return { payload };
       }
     }
     


### PR DESCRIPTION
Dear Oznu and developers.

This PR extends GSH Television device functions such as channel selection. Since the extensions are only confirmed under my limited environment, I wish any developers would evaluate under their configurations and inform the results. Any volunteers? My configuration consists of homebridge-broadlink-rm-pro as an IR blaster to control TV. I also use homebridge-alexa to control TV via voice command.

Background:
From early April, I lost a TV ON/OFF control without specifying full device name. It was really annoying. I thought it was possibly due to missing traits and arose by google side changes. Long story short, my initial guessing was wrong and needed to take an alternative approach, but the implementations are finally completed and working fine now.

Implementation details:
For the accessories having television service, speaker and inputSource services are corrected and merged into GSH Television device. For that purpose, plug-in basic structure was needed to revise. If more than one television/speaker services were found, only the first one is taken and remaining are discarded. Following traits are implemented. 

1. action.devices.traits.Channel
As in homebridge-alexa, inputSource configuredName beginning with 'station -' is handled as a channel and remaining string as a channel name. Channel number is assigned to increment of inputSource identifier. Following commands are implemented and channels can be selected by its name or number, or next/previous.
- action.devices.commands.selectChannel
- action.devices.commands.relativeChannel
- action.devices.commands.returnChannel

2. action.devices.traits.InputSelector
InputSources other than channels are handled as external input of TV. Following commands are implemented and input can be selected by its name or next/previous.
- action.devices.commands.SetInput
- action.devices.commands.NextInput
- action.devices.commands.PreviousInput

3. action.devices.traits.Volume
Following commands are implemented to support incremental volume control. action.devices.commands.setVolume is not implemented, but accidentally triggered while channel number operations. To implement error handling, the plug-in basic structure was needed to be revised again.
- action.devices.commands.mute
- action.devices.commands.volumeRelative

4. action.devices.traits.TransportControl
As in homebridge-alexa,
- action.devices.commands.mediaStop
- action.devices.commands.mediaResume
- action.devices.commands.mediaPause
- action.devices.commands.mediaNext
- action.devices.commands.mediaPrevious
 are mapped to 
- RemoteKey.BACK
- RemoteKey.SELECT
- RemoteKey.PLAY_PAUSE
- RemoteKey.ARROW_RIGHT
- RemoteKey.ARROW_LEFT
respectively. These functions are not tested.

Thanks in advance.
