### PR TITLE
Added Air Purifer device type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Control your supported [Homebridge](https://github.com/nfarina/homebridge) acces
 
 * Switch
 * Outlet
+* Air Purifier
 * Light Bulb
     * On / Off
     * Brightness
@@ -59,16 +60,28 @@ Control your supported [Homebridge](https://github.com/nfarina/homebridge) acces
 
 ## Installation Instructions
 
-#### Option 1: Install via Homebridge Config UI X:
+As this is a fork it needs to be manually installed 
 
-Search for "Google Home" in [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x) and install `homebridge-gsh`.
-
-#### Option 2: Manually Install:
-
+clone repo 
+```bash
+git clone https://github.com/ewandank/homebridge-gsh-air-purifier/
 ```
-sudo npm install -g homebridge-gsh
+install depenedecies
+```bash
+npm install
 ```
-
+Build plugin 
+ ```
+ npm run build:plugin
+ ```
+ In the plugin built directory: 
+ ```
+ npm link
+ ```
+ In the homebridge directory
+ ```
+ npm link homebridge-gsh
+ ```
 ## Configuration
 
 To configure `homebridge-gsh` you must also be running [homebridge-config-ui-x](https://github.com/oznu/homebridge-config-ui-x).

--- a/src/hap.ts
+++ b/src/hap.ts
@@ -8,6 +8,7 @@ import { PluginConfig, HapInstance, HapService, HapCharacteristic, Instance } fr
 import { toLongFormUUID } from './uuid';
 import { Log } from './logger';
 
+import { AirPurifier } from './types/air-purifier';
 import { Door } from './types/door';
 import { Fan } from './types/fan';
 import { Fanv2 } from './types/fan-v2';
@@ -36,6 +37,7 @@ export class Hap {
 
   /* init types */
   types = {
+    AirPurifier: new AirPurifier(), 
     Door: new Door(),
     Fan: new Fan(),
     Fanv2: new Fanv2(),

--- a/src/types/air-purifier.ts
+++ b/src/types/air-purifier.ts
@@ -1,0 +1,62 @@
+import { Characteristic } from '../hap-types';
+import { HapService, AccessoryTypeExecuteResponse } from '../interfaces';
+
+export class AirPurifier {
+  sync(service: HapService) {
+
+    return {
+      id: service.uniqueId,
+      type: 'action.devices.types.AIRPURIFIER',
+      traits: [
+        'action.devices.traits.OnOff',
+      ],
+      name: {
+        defaultNames: [
+          service.serviceName,
+          service.accessoryInformation.Name,
+        ],
+        name: service.serviceName,
+        nicknames: [],
+      },
+      willReportState: true,
+      deviceInfo: {
+        manufacturer: service.accessoryInformation.Manufacturer,
+        model: service.accessoryInformation.Model,
+      },
+      customData: {
+        aid: service.aid,
+        iid: service.iid,
+        instanceUsername: service.instance.username,
+        instanceIpAddress: service.instance.ipAddress,
+        instancePort: service.instance.port,
+      },
+    };
+  }
+
+  query(service: HapService) {
+    return {
+      on: service.characteristics.find(x => x.type === Characteristic.Active).value ? true : false,
+      online: true,
+    };
+  }
+
+  execute(service: HapService, command): AccessoryTypeExecuteResponse {
+    if (!command.execution.length) {
+      return { payload: { characteristics: [] } };
+    }
+
+    switch (command.execution[0].command) {
+      case ('action.devices.commands.OnOff'): {
+        const payload = {
+          characteristics: [{
+            aid: service.aid,
+            iid: service.characteristics.find(x => x.type === Characteristic.Active).iid,
+            value: command.execution[0].params.on ? 1 : 0,
+          }],
+        };
+        return { payload };
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Hi Oznu,
I have added support for Air Purifier devices simply by duplicating fanv2.ts and replacing the name with Air Purifier, as it shares the same mapping of homebridge characteristics to google home actions. I chose to do it in a separate file to allow additional functionality besides on/off to be added in the future. 
Many thanks, 
Ewan